### PR TITLE
Use license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,13 +3,8 @@
 	"version": "0.5.1",
 	"author": "Tobias Koppers @sokra",
 	"description": "json loader module for webpack",
-	"licenses": [
-		{
-			"type": "MIT",
-			"url": "http://www.opensource.org/licenses/mit-license.php"
-		}
-	],
-	"repository": { 
+	"license": "MIT",
+	"repository": {
 		"type": "git",
 		"url" : "https://github.com/webpack/json-loader.git"
 	}


### PR DESCRIPTION
Array deprecated in `npm@2.10.0`

https://github.com/npm/npm/blob/master/doc/files/package.json.md#license