### PR TITLE
Fix when multiple

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,5 +6,5 @@ module.exports = function(source) {
 	this.cacheable && this.cacheable();
 	var value = JSON.parse(source);
 	this.value = [value];
-	return "module.exports = " + JSON.stringify(value, undefined, "\t");
+	return "module.exports = " + JSON.stringify(value, undefined, "\t") + ";";
 }


### PR DESCRIPTION
Hi,

When I had multiple .json files being dynamically required, only the first was being recognised (target: node). Adding this semicolon makes the statement valid and fixes my problem. Thanks!