### PR TITLE
making sure source is string before parsing

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
 */
 module.exports = function(source) {
 	this.cacheable && this.cacheable();
-	var value = JSON.parse(source);
+	var value = typeof source === "string" ? JSON.parse(source) : source;
 	this.value = [value];
-	return "module.exports = " + JSON.stringify(value, undefined, "\t");
+	return "module.exports = " + JSON.stringify(value, undefined, "\t") + ";";
 }


### PR DESCRIPTION
There is only one require in my sample app.
```
let pc = require("json-loader!./mock/welcome-page.json");
```
and I have been getting errors
```
ERROR in ./~/json-loader!./src/mock/welcome-page.json
Module build failed: SyntaxError: Unexpected token m
    at Object.parse (native)
    at Object.module.exports (/Users/ktan7/cxo-react/checkout/node_modules/json-loader/index.js:7:19)
 @ ./src/demo-app.jsx 21:13-60
```