### PR TITLE
Extra `!` for the json-loader closes #13

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## Usage
 
 ``` javascript
-var json = require("json!./file.json");
+var json = require("!json!./file.json");
 // => returns file.json content as json parsed object
 ```
 


### PR DESCRIPTION
Not sure if this is the only option but it worked with the following code:

- `import/require` - `import Data from '!json!../../data';` (`.json` is resolved)
- Loader: `{ test: /\.json$/, loaders: ['json-loader'] }`
- From: https://github.com/webpack/webpack/tree/master/examples/loader