### PR TITLE
Update README with -loader suffix to reflect Webpack 2 change

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## Usage
 
 ``` javascript
-var json = require("json!./file.json");
+var json = require("json-loader!./file.json");
 // => returns file.json content as json parsed object
 ```
 


### PR DESCRIPTION
Summary:
----

Webpack v2.1.0-beta.26 introduced a breaking change to require loaders to have the `-loader` suffix. 

This PR updates the README to show that pattern as an example instead of using the shorthand naming.

cc: @sokra @SpaceK33z 