### PR TITLE
refactor: use `jsesc` to escape special characters

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,12 @@
+const jsesc = require('jsesc');
+
 module.exports = function (source) {
   if (this.cacheable) this.cacheable();
 
   var value = typeof source === "string" ? JSON.parse(source) : source;
 
-  value = JSON.stringify(value)
-    .replace(/\u2028/g, '\\u2028')
-    .replace(/\u2029/g, '\\u2029');
+  value = JSON.stringify(value);
+  value = jsesc(value);
 
   return `module.exports = ${value}`;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -760,6 +760,11 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
+    "jsesc": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
+      "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4="
+    },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -13,5 +13,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/webpack/json-loader.git"
+  },
+  "dependencies": {
+    "jsesc": "^2.5.1"
   }
 }


### PR DESCRIPTION
Similar to https://github.com/webpack-contrib/raw-loader/pull/36 we can use
jsesc here to deal with special characters in general.